### PR TITLE
Allow to force display an image with ?img= query param

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,17 @@
       }
 
       function loadRandomPicture() {
-        var picture = PICTURES[Math.floor(Math.random()*PICTURES.length)];
+        var queryParams = new URLSearchParams(document.location.search);
+        var forcedPictureFromQuery = PICTURES.find(function (element) {
+          return element.src.includes("img/" + queryParams.get("img") + ".")
+        });
+
+        if (forcedPictureFromQuery !== undefined) {
+          var picture = forcedPictureFromQuery;
+        } else {
+          var picture = PICTURES[Math.floor(Math.random()*PICTURES.length)];
+        }
+
         var img = document.getElementById('lys-img');
         img.src = picture.src;
         img.alt = picture.alt;


### PR DESCRIPTION
I thought it might be nice to be able to force an image using the query string :)

For instance, with the url `https://lockyourscreen.com?img=captain-holt` I will always see:

<img width="813" alt="Capture d’écran 2023-04-28 à 16 48 21" src="https://user-images.githubusercontent.com/12596207/235179853-2ced6f5f-cf1b-41be-856b-4d8c80c85b74.png">
